### PR TITLE
Feat/project#51 프로젝트 생성 API

### DIFF
--- a/src/main/java/com/ll/dopdang/domain/category/entity/Category.java
+++ b/src/main/java/com/ll/dopdang/domain/category/entity/Category.java
@@ -1,0 +1,40 @@
+package com.ll.dopdang.domain.category.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Category {
+
+	@Id
+	private Integer id;
+
+	@ManyToOne
+	@JoinColumn(name = "parent_id")
+	private Category parent;
+
+	@Column(nullable = false, length = 100)
+	private String name;
+
+	@Column(nullable = false)
+	private boolean level;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "category_type", nullable = false, length = 50)
+	private CategoryType categoryType;
+
+}
+

--- a/src/main/java/com/ll/dopdang/domain/category/entity/Category.java
+++ b/src/main/java/com/ll/dopdang/domain/category/entity/Category.java
@@ -4,6 +4,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -20,7 +22,8 @@ import lombok.NoArgsConstructor;
 public class Category {
 
 	@Id
-	private Integer id;
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
 	@ManyToOne
 	@JoinColumn(name = "parent_id")

--- a/src/main/java/com/ll/dopdang/domain/category/entity/CategoryType.java
+++ b/src/main/java/com/ll/dopdang/domain/category/entity/CategoryType.java
@@ -1,0 +1,7 @@
+package com.ll.dopdang.domain.category.entity;
+
+public enum CategoryType {
+	PROJECT,
+	PROVISION,
+	PRODUCT
+}

--- a/src/main/java/com/ll/dopdang/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.ll.dopdang.domain.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.dopdang.domain.category.entity.Category;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/ll/dopdang/domain/expert/entity/Expert.java
+++ b/src/main/java/com/ll/dopdang/domain/expert/entity/Expert.java
@@ -1,0 +1,55 @@
+package com.ll.dopdang.domain.expert.entity;
+
+import com.ll.dopdang.domain.category.entity.Category;
+import com.ll.dopdang.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Expert {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne
+	@JoinColumn(name = "category_id", nullable = false)
+	private Category category;
+
+	private String introduction;
+
+	private int careerYears;
+
+	private String certification;
+
+	private Boolean gender; // 0 남자 1 여자
+
+	@Column(nullable = false, length = 100)
+	private String bankName; // 은행명
+
+	@Column(nullable = false, length = 100)
+	private String accountNumber; // 계좌번호
+
+	private boolean isAvailability;
+
+	private String sellerInfo;
+}

--- a/src/main/java/com/ll/dopdang/domain/expert/entity/Expert.java
+++ b/src/main/java/com/ll/dopdang/domain/expert/entity/Expert.java
@@ -41,7 +41,7 @@ public class Expert {
 
 	private String certification;
 
-	private Boolean gender; // 0 남자 1 여자
+	//private Boolean gender; // 0 남자 1 여자
 
 	@Column(nullable = false, length = 100)
 	private String bankName; // 은행명
@@ -49,7 +49,7 @@ public class Expert {
 	@Column(nullable = false, length = 100)
 	private String accountNumber; // 계좌번호
 
-	private boolean isAvailability;
+	private boolean availability;
 
 	private String sellerInfo;
 }

--- a/src/main/java/com/ll/dopdang/domain/expert/repository/ExpertRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/expert/repository/ExpertRepository.java
@@ -1,0 +1,10 @@
+package com.ll.dopdang.domain.expert.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ll.dopdang.domain.expert.entity.Expert;
+
+@Repository
+public interface ExpertRepository extends JpaRepository<Expert, Long> {
+}

--- a/src/main/java/com/ll/dopdang/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/ll/dopdang/domain/project/controller/ProjectController.java
@@ -27,7 +27,8 @@ public class ProjectController {
 
 	@Operation(
 		summary = "프로젝트 생성",
-		description = "고객이 새로운 프로젝트를 생성합니다. 인증된 사용자의 ID를 기반으로 프로젝트가 생성되며, 요청 본문에는 프로젝트의 카테고리, 제목, 지역, 예산, 마감일 등이 포함되어야 합니다.",
+		description = "고객이 새로운 프로젝트를 생성합니다. 인증된 사용자의 ID를 기반으로 프로젝트가 생성되며, "
+			+ "요청 본문에는 프로젝트의 카테고리, 제목, 지역, 예산, 마감일 등이 포함되어야 합니다.",
 		tags = {"Project"}
 	)
 	@ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")

--- a/src/main/java/com/ll/dopdang/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/ll/dopdang/domain/project/controller/ProjectController.java
@@ -1,0 +1,57 @@
+package com.ll.dopdang.domain.project.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ll.dopdang.domain.project.dto.ProjectCreateRequest;
+import com.ll.dopdang.domain.project.dto.ProjectCreateResponse;
+import com.ll.dopdang.domain.project.service.ProjectService;
+import com.ll.dopdang.global.security.custom.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/projects")
+public class ProjectController {
+	private final ProjectService projectService;
+
+	@Operation(
+		summary = "프로젝트 생성",
+		description = "고객이 새로운 프로젝트를 생성합니다. 인증된 사용자의 ID를 기반으로 프로젝트가 생성되며, 요청 본문에는 프로젝트의 카테고리, 제목, 지역, 예산, 마감일 등이 포함되어야 합니다.",
+		tags = {"Project"}
+	)
+	@ApiResponse(responseCode = "201", description = "프로젝트 생성 성공")
+	@ApiResponse(responseCode = "400", description = "유효하지 않은 입력 값")
+	@ApiResponse(responseCode = "401", description = "인증 실패")
+	@ApiResponse(responseCode = "404", description = "카테고리 또는 전문가를 찾을 수 없음")
+	@PostMapping
+	public ResponseEntity<ProjectCreateResponse> createProject(
+		@io.swagger.v3.oas.annotations.parameters.RequestBody(
+			description = "프로젝트 생성 요청 객체", required = true
+		)
+		@Valid @RequestBody ProjectCreateRequest request,
+
+		@Parameter(hidden = true)
+		@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		Long clientId = userDetails.getId();
+		Long projectId = projectService.createProject(request, clientId);
+
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(new ProjectCreateResponse(
+				projectId,
+				"프로젝트가 성공적으로 생성되었습니다. (ID: " + projectId + ")"
+			));
+	}
+
+}

--- a/src/main/java/com/ll/dopdang/domain/project/dto/ProjectCreateRequest.java
+++ b/src/main/java/com/ll/dopdang/domain/project/dto/ProjectCreateRequest.java
@@ -1,0 +1,53 @@
+package com.ll.dopdang.domain.project.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ProjectCreateRequest {
+
+	@NotNull(message = "카테고리 ID는 필수입니다.")
+	private Long categoryId;
+
+	@NotBlank(message = "프로젝트 제목은 필수입니다.")
+	private String title;
+
+	@NotBlank(message = "프로젝트 한줄 요약은 필수입니다.")
+	@Schema(description = "프로젝트 한줄 요약", example = "강아지를 위한 스마트 급식기 개발")
+	private String summary;
+
+	@NotBlank(message = "프로젝트 설명을 적어주세요.")
+	@Schema(description = "프로젝트 상세 설명", example = "강아지를 집에 혼자 둘 때에도 사료를 시간에 맞춰 줄 수 있는 스마트 급식기를 만들고자 합니다.")
+	private String description;
+
+	@NotBlank(message = "지역 정보는 필수입니다.")
+	@Schema(description = "프로젝트 진행 지역", example = "서울특별시 강남구")
+	private String region;
+
+	@PositiveOrZero(message = "예산은 0 이상이어야 합니다.")
+	@Schema(description = "프로젝트 예산", example = "500000")
+	private BigDecimal budget;
+
+	@FutureOrPresent(message = "마감일은 현재 시각 이후여야 합니다.")
+	@Schema(description = "프로젝트 마감일", example = "2025-06-30T23:59:59")
+	private LocalDateTime deadline;
+
+	// 없을 수도 있음
+	@Schema(description = "선택 항목: 지정 전문가 ID", example = "42")
+	private Long expertId;
+
+	@Schema(description = "프로젝트 이미지 URL 리스트", example = "[\"https://example.com/image1.jpg\", \"https://example.com/image2.jpg\"]")
+	private List<@NotBlank String> imageUrls;
+}

--- a/src/main/java/com/ll/dopdang/domain/project/dto/ProjectCreateResponse.java
+++ b/src/main/java/com/ll/dopdang/domain/project/dto/ProjectCreateResponse.java
@@ -1,0 +1,18 @@
+package com.ll.dopdang.domain.project.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "프로젝트 생성 응답 DTO")
+public class ProjectCreateResponse {
+
+	@Schema(description = "생성된 프로젝트 ID", example = "42")
+	private Long projectId;
+
+	@Schema(description = "응답 메시지", example = "프로젝트가 성공적으로 생성되었습니다. (ID: 42)")
+	private String message;
+
+}

--- a/src/main/java/com/ll/dopdang/domain/project/entity/Project.java
+++ b/src/main/java/com/ll/dopdang/domain/project/entity/Project.java
@@ -19,12 +19,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Project extends BaseEntity {
 
 	@Id
@@ -39,10 +43,17 @@ public class Project extends BaseEntity {
 	@JoinColumn(name = "category_id", nullable = false)
 	private Category category;
 
+	@Column(nullable = false, length = 200)
 	private String title;
 
-	@Column(columnDefinition = "TEXT")
+	@Column(nullable = false, length = 100)
+	private String summary;
+
+	@Column(columnDefinition = "TEXT", nullable = true)
 	private String description;
+
+	@Column(nullable = false, length = 200)
+	private String region;
 
 	private BigDecimal budget;
 

--- a/src/main/java/com/ll/dopdang/domain/project/entity/Project.java
+++ b/src/main/java/com/ll/dopdang/domain/project/entity/Project.java
@@ -1,0 +1,59 @@
+package com.ll.dopdang.domain.project.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.ll.dopdang.domain.category.entity.Category;
+import com.ll.dopdang.domain.expert.entity.Expert;
+import com.ll.dopdang.domain.member.entity.Member;
+import com.ll.dopdang.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Project extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "client_id", nullable = false)
+	private Member client;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_id", nullable = false)
+	private Category category;
+
+	private String title;
+
+	@Column(columnDefinition = "TEXT")
+	private String description;
+
+	private BigDecimal budget;
+
+	private LocalDateTime deadline;
+
+	@Enumerated(EnumType.STRING)
+	private ProjectStatus status;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "expert_id")
+	private Expert expert;
+
+	// 생성자, 비즈니스 로직 등...
+}

--- a/src/main/java/com/ll/dopdang/domain/project/entity/ProjectImage.java
+++ b/src/main/java/com/ll/dopdang/domain/project/entity/ProjectImage.java
@@ -1,0 +1,40 @@
+package com.ll.dopdang.domain.project.entity;
+
+import com.ll.dopdang.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProjectImage extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "project_id", nullable = false)
+	private Project project;
+
+	@Column(nullable = false, length = 255)
+	private String imageUrl;
+
+	@Column(nullable = false)
+	private Integer orderNum;
+
+}

--- a/src/main/java/com/ll/dopdang/domain/project/entity/ProjectStatus.java
+++ b/src/main/java/com/ll/dopdang/domain/project/entity/ProjectStatus.java
@@ -1,0 +1,18 @@
+package com.ll.dopdang.domain.project.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum ProjectStatus {
+	OPEN("open"),
+	IN_PROGRESS("in_progress"),
+	COMPLETED("completed"),
+	CANCELLED("cancelled");
+
+	private final String value;
+
+	ProjectStatus(String value) {
+		this.value = value;
+	}
+
+}

--- a/src/main/java/com/ll/dopdang/domain/project/repository/ProjectImageRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/project/repository/ProjectImageRepository.java
@@ -1,0 +1,15 @@
+package com.ll.dopdang.domain.project.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.dopdang.domain.project.entity.Project;
+import com.ll.dopdang.domain.project.entity.ProjectImage;
+
+public interface ProjectImageRepository extends JpaRepository<ProjectImage, Long> {
+
+	// 특정 프로젝트에 연관된 이미지 전체 조회 (순서 포함)
+	List<ProjectImage> findAllByProjectOrderByOrderNumAsc(Project project);
+
+}

--- a/src/main/java/com/ll/dopdang/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/project/repository/ProjectRepository.java
@@ -1,0 +1,9 @@
+package com.ll.dopdang.domain.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.ll.dopdang.domain.project.entity.Project;
+
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+
+}

--- a/src/main/java/com/ll/dopdang/domain/project/service/ProjectService.java
+++ b/src/main/java/com/ll/dopdang/domain/project/service/ProjectService.java
@@ -1,0 +1,85 @@
+package com.ll.dopdang.domain.project.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ll.dopdang.domain.category.entity.Category;
+import com.ll.dopdang.domain.category.repository.CategoryRepository;
+import com.ll.dopdang.domain.expert.entity.Expert;
+import com.ll.dopdang.domain.expert.repository.ExpertRepository;
+import com.ll.dopdang.domain.member.entity.Member;
+import com.ll.dopdang.domain.member.repository.MemberRepository;
+import com.ll.dopdang.domain.project.dto.ProjectCreateRequest;
+import com.ll.dopdang.domain.project.entity.Project;
+import com.ll.dopdang.domain.project.entity.ProjectImage;
+import com.ll.dopdang.domain.project.entity.ProjectStatus;
+import com.ll.dopdang.domain.project.repository.ProjectImageRepository;
+import com.ll.dopdang.domain.project.repository.ProjectRepository;
+import com.ll.dopdang.global.exception.ErrorCode;
+import com.ll.dopdang.global.exception.ServiceException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProjectService {
+	private final ProjectRepository projectRepository;
+	private final MemberRepository memberRepository;
+	private final CategoryRepository categoryRepository;
+	private final ExpertRepository expertRepository;
+	private final ProjectImageRepository projectImageRepository;
+
+	public Long createProject(ProjectCreateRequest request, Long clientId) {
+		// 1. 클라이언트(회원) 조회
+		Member client = memberRepository.findById(clientId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.MEMBER_NOT_FOUND));
+
+		// 2. 카테고리 조회
+		Category category = categoryRepository.findById(request.getCategoryId())
+			.orElseThrow(() -> new ServiceException(ErrorCode.CATEGORY_NOT_FOUND));
+
+		// 3. 전문가가 선택되었는지 확인 후 조회 (선택적)
+		Expert expert = null;
+		if (request.getExpertId() != null) {
+			expert = expertRepository.findById(request.getExpertId())
+				.orElseThrow(() -> new ServiceException(ErrorCode.EXPERT_NOT_FOUND));
+		}
+
+		// 4. 프로젝트 엔티티 생성
+		Project project = Project.builder()
+			.client(client)
+			.category(category)
+			.title(request.getTitle())
+			.summary(request.getSummary())
+			.description(request.getDescription())
+			.region(request.getRegion())
+			.budget(request.getBudget())
+			.deadline(request.getDeadline())
+			.status(ProjectStatus.OPEN)
+			.expert(expert)
+			.build();
+
+		// 5. 저장
+		Project savedProject = projectRepository.save(project);
+
+		// 6. 이미지가 있다면 ProjectImage 엔티티로 변환 후 저장
+		List<String> imageUrls = request.getImageUrls();
+		if (imageUrls != null && !imageUrls.isEmpty()) {
+			List<ProjectImage> images = new ArrayList<>();
+			int order = 0;
+			for (String url : imageUrls) {
+				images.add(ProjectImage.builder()
+					.project(savedProject)
+					.imageUrl(url)
+					.orderNum(order++) // 순서 보장
+					.build());
+			}
+			projectImageRepository.saveAll(images);
+		}
+
+		// 7. 최종적으로 프로젝트 ID 반환
+		return savedProject.getId();
+	}
+}

--- a/src/main/java/com/ll/dopdang/global/config/S3Config.java
+++ b/src/main/java/com/ll/dopdang/global/config/S3Config.java
@@ -3,6 +3,7 @@ package com.ll.dopdang.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;

--- a/src/main/java/com/ll/dopdang/global/exception/ErrorCode.java
+++ b/src/main/java/com/ll/dopdang/global/exception/ErrorCode.java
@@ -43,7 +43,11 @@ public enum ErrorCode {
 	PHONE_VERIFICATION_FAILED(HttpStatus.BAD_REQUEST, "전화번호 인증에 실패하였습니다."),
 	PASSWORD_SAME_AS_CURRENT(HttpStatus.BAD_REQUEST, "현재 사용중인 비밀번호와 일치합니다."),
 	UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "인증되지 않은 유저입니다."),
-
+	// 카테고리 관련 에러
+	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+	// 전문가 관련 에러
+	EXPERT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전문가입니다."),
+	INVALID_EXPERT_ASSIGNMENT(HttpStatus.BAD_REQUEST, "지정된 전문가 정보를 확인할 수 없습니다."),
 	// S3 Presigned URL 생성 관련
 	PRESIGNED_URL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Presigned URL 생성 중 알 수 없는 오류가 발생했습니다."),
 	INVALID_S3_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청으로 인해 S3 Presigned URL 생성에 실패했습니다."),

--- a/src/main/java/com/ll/dopdang/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ll/dopdang/global/exception/GlobalExceptionHandler.java
@@ -25,17 +25,17 @@ public class GlobalExceptionHandler {
 	/**
 	 * ServiceException 처리를 위한 핸들러
 	 *
-	 * @param e ServiceException
+	 * @param exception ServiceException
 	 * @return 에러 응답
 	 */
 	@ExceptionHandler(ServiceException.class)
-	public ResponseEntity<ErrorResponse> handleServiceException(ServiceException e) {
-		log.error("ServiceException 발생: {}", e.getMessage());
+	public ResponseEntity<ErrorResponse> handleServiceException(ServiceException exception) {
+		log.error("ServiceException 발생: {}", exception.getMessage());
 
-		ErrorCode errorCode = e.getErrorCode();
+		ErrorCode errorCode = exception.getErrorCode();
 		ErrorResponse response = ErrorResponse.builder()
 			.status(errorCode.getStatus().value())
-			.message(e.getMessage())
+			.message(exception.getMessage())
 			.timestamp(LocalDateTime.now())
 			.build();
 
@@ -47,22 +47,23 @@ public class GlobalExceptionHandler {
 	 * 날짜 형식 오류에 대한 명확한 메시지 제공
 	 */
 	@ExceptionHandler(HttpMessageNotReadableException.class)
-	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-		log.error("메시지 변환 오류: {}", e.getMessage());
+	public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(
+		HttpMessageNotReadableException exception) {
+		log.error("메시지 변환 오류: {}", exception.getMessage());
 
 		String message = "요청 본문을 처리할 수 없습니다.";
 
 		// 날짜 형식 오류 처리
-		if (e.getCause() instanceof InvalidFormatException ife) {
+		if (exception.getCause() instanceof InvalidFormatException ife) {
 			if (ife.getTargetType() != null
 				&& (ife.getTargetType().equals(LocalDateTime.class)
 				|| ife.getTargetType().equals(LocalDate.class))) {
 				message = "날짜 형식이 올바르지 않습니다. 'yyyy-MM-dd' 또는 'yyyy-MM-dd'T'HH:mm:ss' 형식을 사용해주세요.";
 			}
-		} else if (e.getCause() instanceof IllegalArgumentException
-			&& e.getCause().getMessage() != null
-			&& e.getCause().getMessage().contains("날짜 형식이 올바르지 않습니다")) {
-			message = e.getCause().getMessage();
+		} else if (exception.getCause() instanceof IllegalArgumentException
+			&& exception.getCause().getMessage() != null
+			&& exception.getCause().getMessage().contains("날짜 형식이 올바르지 않습니다")) {
+			message = exception.getCause().getMessage();
 		}
 
 		ErrorResponse response = ErrorResponse.builder()
@@ -78,8 +79,8 @@ public class GlobalExceptionHandler {
 	 * 입력값 검증 실패 예외 처리
 	 */
 	@ExceptionHandler({MethodArgumentNotValidException.class, BindException.class})
-	public ResponseEntity<ErrorResponse> handleValidationException(Exception e) {
-		log.error("입력값 검증 실패: {}", e.getMessage());
+	public ResponseEntity<ErrorResponse> handleValidationException(Exception exception) {
+		log.error("입력값 검증 실패: {}", exception.getMessage());
 
 		ErrorResponse response = ErrorResponse.builder()
 			.status(HttpStatus.BAD_REQUEST.value())
@@ -93,12 +94,12 @@ public class GlobalExceptionHandler {
 	/**
 	 * 기타 예외 처리를 위한 핸들러
 	 *
-	 * @param e Exception
+	 * @param exception Exception
 	 * @return 에러 응답
 	 */
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<ErrorResponse> handleException(Exception e) {
-		log.error("예외 발생: {}", e.getMessage(), e);
+	public ResponseEntity<ErrorResponse> handleException(Exception exception) {
+		log.error("예외 발생: {}", exception.getMessage(), exception);
 
 		ErrorResponse response = ErrorResponse.builder()
 			.status(HttpStatus.INTERNAL_SERVER_ERROR.value())

--- a/src/main/java/com/ll/dopdang/global/s3/PresignedUrlResponse.java
+++ b/src/main/java/com/ll/dopdang/global/s3/PresignedUrlResponse.java
@@ -8,4 +8,5 @@ public record PresignedUrlResponse(
 	@Schema(description = "S3에 파일을 업로드할 수 있는 미리 서명된 URL", example = "https://bucket-name.s3.ap-northeast-2.amazonaws.com/path/to/file?X-Amz-Algorithm=...")
 	String presignedUrl
 
-) {}
+) {
+}

--- a/src/main/java/com/ll/dopdang/global/s3/S3Controller.java
+++ b/src/main/java/com/ll/dopdang/global/s3/S3Controller.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -33,8 +34,10 @@ public class S3Controller {
 	@GetMapping("/project-image")
 	public ResponseEntity<PresignedUrlResponse> getProjectImagePresignedUrl(
 		@Parameter(description = "프로젝트 ID", example = "1") @RequestParam Long projectId,
-		@Parameter(description = "저장할 파일 이름 (확장자 포함)", example = "project_image.png") @RequestParam String fileName,
-		@Parameter(description = "파일 MIME 타입 (예: image/png, image/jpeg)", example = "image/png") @RequestParam String contentType
+		@Parameter(description = "저장할 파일 이름 (확장자 포함)",
+			example = "project_image.png") @RequestParam String fileName,
+		@Parameter(description = "파일 MIME 타입 (예: image/png, image/jpeg)",
+			example = "image/png") @RequestParam String contentType
 	) {
 		URL url = s3Service.generatePresignedUrlForProjectImage(projectId, fileName, contentType);
 		return ResponseEntity.ok(new PresignedUrlResponse(url.toString()));
@@ -47,8 +50,10 @@ public class S3Controller {
 	@GetMapping("/member-profile")
 	public ResponseEntity<PresignedUrlResponse> getMemberProfilePresignedUrl(
 		@Parameter(description = "회원 ID", example = "42") @RequestParam Long memberId,
-		@Parameter(description = "저장할 파일 이름 (확장자 포함)", example = "profile_image.png") @RequestParam String fileName,
-		@Parameter(description = "파일 MIME 타입 (예: image/png, image/jpeg)", example = "image/png") @RequestParam String contentType
+		@Parameter(description = "저장할 파일 이름 (확장자 포함)",
+			example = "profile_image.png") @RequestParam String fileName,
+		@Parameter(description = "파일 MIME 타입 (예: image/png, image/jpeg)",
+			example = "image/png") @RequestParam String contentType
 	) {
 		URL url = s3Service.generatePresignedUrlForMemberProfile(memberId, fileName, contentType);
 		return ResponseEntity.ok(new PresignedUrlResponse(url.toString()));


### PR DESCRIPTION
프론트앤드 추가 요청사항까지 반영된 프로젝트 생성 API 입니다

## 구현 내용
- 고객이 프로젝트를 생성할 수 있는 API (`POST /projects`) 구현
- 프로젝트 생성 시 다음 항목 필수 입력:
  - 카테고리 ID
  - 제목, 한줄 요약(summary), 설명
  - 지역(region), 예산, 마감일
- 선택 입력:
  - 전문가 ID (매칭되지 않은 경우 null 가능)
  - 프로젝트 이미지 URL 리스트 (이미지가 있을 경우 ProjectImage 테이블에 저장)

## 반영된 엔티티/DTO
- Project, ProjectImage 엔티티 추가 및 수정
- ProjectCreateRequest DTO에 summary, imageUrls 추가
- ProjectService 로직에 이미지 저장 처리 추가