### PR TITLE
Feat/project#51 프로젝트 단건 조회 API 개발

### DIFF
--- a/src/main/java/com/ll/dopdang/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/ll/dopdang/domain/project/controller/ProjectController.java
@@ -3,6 +3,8 @@ package com.ll.dopdang.domain.project.controller;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.ll.dopdang.domain.project.dto.ProjectCreateRequest;
 import com.ll.dopdang.domain.project.dto.ProjectCreateResponse;
+import com.ll.dopdang.domain.project.dto.ProjectDetailResponse;
 import com.ll.dopdang.domain.project.service.ProjectService;
 import com.ll.dopdang.global.security.custom.CustomUserDetails;
 
@@ -55,4 +58,19 @@ public class ProjectController {
 			));
 	}
 
+	@Operation(
+		summary = "프로젝트 단건 조회",
+		description = "프로젝트 ID를 기반으로 단일 프로젝트의 상세 정보를 조회합니다.",
+		tags = {"Project"}
+	)
+	@ApiResponse(responseCode = "200", description = "프로젝트 조회 성공")
+	@ApiResponse(responseCode = "404", description = "해당 프로젝트를 찾을 수 없음")
+	@GetMapping("/{projectId}")
+	public ResponseEntity<ProjectDetailResponse> getProjectById(
+		@Parameter(description = "조회할 프로젝트의 ID", required = true, example = "1")
+		@PathVariable Long projectId
+	) {
+		ProjectDetailResponse response = projectService.getProjectById(projectId);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/src/main/java/com/ll/dopdang/domain/project/dto/ProjectDetailResponse.java
+++ b/src/main/java/com/ll/dopdang/domain/project/dto/ProjectDetailResponse.java
@@ -1,0 +1,52 @@
+package com.ll.dopdang.domain.project.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.ll.dopdang.domain.member.entity.Member;
+import com.ll.dopdang.domain.project.entity.Project;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProjectDetailResponse {
+
+	private Long id;
+	private String title;
+	private String summary;
+	private String description;
+	private String region;
+	private BigDecimal budget;
+	private LocalDateTime deadline;
+	private String status;
+
+	private String clientName;
+	private String clientProfileImageUrl;
+
+	private List<String> imageUrls;
+
+	public static ProjectDetailResponse of(Project project, List<String> imageUrls) {
+		Member client = project.getClient();
+
+		return ProjectDetailResponse.builder()
+			.id(project.getId())
+			.title(project.getTitle())
+			.summary(project.getSummary())
+			.description(project.getDescription())
+			.region(project.getRegion())
+			.budget(project.getBudget())
+			.deadline(project.getDeadline())
+			.status(project.getStatus().name())
+			.clientName(client.getName())
+			.clientProfileImageUrl(client.getProfileImage())
+			.imageUrls(imageUrls)
+			.build();
+	}
+}

--- a/src/main/java/com/ll/dopdang/domain/project/entity/ProjectStatus.java
+++ b/src/main/java/com/ll/dopdang/domain/project/entity/ProjectStatus.java
@@ -1,7 +1,22 @@
 package com.ll.dopdang.domain.project.entity;
 
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.ll.dopdang.global.exception.ErrorCode;
+import com.ll.dopdang.global.exception.ServiceException;
+
 import lombok.Getter;
 
+/**
+ * 프로젝트 상태를 나타내는 열거형.
+ * OPEN - 모집 중
+ * IN_PROGRESS - 작업 진행 중
+ * COMPLETED - 작업 완료 후 구매 확정
+ * CANCELLED - 취소 또는 문제 해결
+ * 프론트엔드에서 문자열로 요청하는 상태 값을 역직렬화하여 Enum으로 매핑할 수 있도록
+ * {@link JsonCreator}를 사용한 from() 메서드를 제공한다.
+ */
 @Getter
 public enum ProjectStatus {
 	OPEN("open"),
@@ -15,4 +30,19 @@ public enum ProjectStatus {
 		this.value = value;
 	}
 
+	/**
+	 * 문자열 값을 Enum으로 변환하는 메서드.
+	 * 프론트에서 요청 시 status=open 같은 값이 들어올 때 이 메서드를 통해 Enum으로 매핑된다.
+	 *
+	 * @param value 문자열 형태의 상태 값
+	 * @return 해당하는 ProjectStatus Enum
+	 * @throws ServiceException 잘못된 값이 들어왔을 경우 예외 발생
+	 */
+	@JsonCreator
+	public static ProjectStatus from(String value) {
+		return Arrays.stream(ProjectStatus.values())
+			.filter(e -> e.getValue().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(() -> new ServiceException(ErrorCode.INVALID_PROJECT_STATUS));
+	}
 }

--- a/src/main/java/com/ll/dopdang/domain/project/repository/ProjectImageRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/project/repository/ProjectImageRepository.java
@@ -4,12 +4,11 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.ll.dopdang.domain.project.entity.Project;
 import com.ll.dopdang.domain.project.entity.ProjectImage;
 
 public interface ProjectImageRepository extends JpaRepository<ProjectImage, Long> {
 
 	// 특정 프로젝트에 연관된 이미지 전체 조회 (순서 포함)
-	List<ProjectImage> findAllByProjectOrderByOrderNumAsc(Project project);
+	List<ProjectImage> findByProjectIdOrderByOrderNumAsc(Long projectId);
 
 }

--- a/src/main/java/com/ll/dopdang/domain/project/service/ProjectService.java
+++ b/src/main/java/com/ll/dopdang/domain/project/service/ProjectService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.dopdang.domain.category.entity.Category;
 import com.ll.dopdang.domain.category.repository.CategoryRepository;
@@ -12,6 +13,7 @@ import com.ll.dopdang.domain.expert.repository.ExpertRepository;
 import com.ll.dopdang.domain.member.entity.Member;
 import com.ll.dopdang.domain.member.repository.MemberRepository;
 import com.ll.dopdang.domain.project.dto.ProjectCreateRequest;
+import com.ll.dopdang.domain.project.dto.ProjectDetailResponse;
 import com.ll.dopdang.domain.project.entity.Project;
 import com.ll.dopdang.domain.project.entity.ProjectImage;
 import com.ll.dopdang.domain.project.entity.ProjectStatus;
@@ -31,6 +33,17 @@ public class ProjectService {
 	private final ExpertRepository expertRepository;
 	private final ProjectImageRepository projectImageRepository;
 
+	/**
+	 * 새로운 프로젝트를 생성하고, 프로젝트 이미지가 있다면 함께 저장합니다.
+	 * 요청 객체에서 전달받은 정보로 Project 엔티티를 생성하며,
+	 * 프로젝트에 연결된 카테고리와 클라이언트(Member)를 조회합니다.
+	 * 선택적으로 전문가(Expert)도 연결할 수 있습니다.
+	 * 프로젝트 생성 후 이미지 URL이 존재할 경우, ProjectImage 엔티티를 순서대로 저장합니다.
+	 *
+	 * @param request   프로젝트 생성 요청 DTO (카테고리 ID, 제목, 설명, 지역, 예산, 마감일, 이미지 URL 등 포함)
+	 * @param clientId  현재 인증된 사용자(클라이언트)의 ID
+	 * @return 생성된 프로젝트의 ID
+	 */
 	public Long createProject(ProjectCreateRequest request, Long clientId) {
 		// 1. 클라이언트(회원) 조회
 		Member client = memberRepository.findById(clientId)
@@ -82,4 +95,30 @@ public class ProjectService {
 		// 7. 최종적으로 프로젝트 ID 반환
 		return savedProject.getId();
 	}
+
+	/**
+	 * 프로젝트 ID로 단건 조회
+	 *
+	 * @param projectId 조회할 프로젝트의 ID
+	 * @return 프로젝트 상세 응답 DTO
+	 * @throws ServiceException 프로젝트가 존재하지 않을 경우 예외 발생
+	 */
+	@Transactional(readOnly = true)
+	public ProjectDetailResponse getProjectById(Long projectId) {
+		// 1. 프로젝트 조회
+		Project project = projectRepository.findById(projectId)
+			.orElseThrow(() -> new ServiceException(ErrorCode.PROJECT_NOT_FOUND));
+
+		// 2. 프로젝트에 연결된 이미지들을 순서대로 조회
+		List<ProjectImage> images = projectImageRepository.findByProjectIdOrderByOrderNumAsc(projectId);
+
+		// 3. 이미지 URL만 추출
+		List<String> imageUrls = images.stream()
+			.map(ProjectImage::getImageUrl)
+			.toList();
+
+		// 4. DTO 변환 및 반환
+		return ProjectDetailResponse.of(project, imageUrls);
+	}
+
 }

--- a/src/main/java/com/ll/dopdang/global/exception/ErrorCode.java
+++ b/src/main/java/com/ll/dopdang/global/exception/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
 	// 전문가 관련 에러
 	EXPERT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 전문가입니다."),
 	INVALID_EXPERT_ASSIGNMENT(HttpStatus.BAD_REQUEST, "지정된 전문가 정보를 확인할 수 없습니다."),
+	// 프로젝트 관련 에러
+	PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
+	INVALID_PROJECT_STATUS(HttpStatus.BAD_REQUEST, "프로젝트 상태 값이 올바르지 않습니다."),
 	// S3 Presigned URL 생성 관련
 	PRESIGNED_URL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Presigned URL 생성 중 알 수 없는 오류가 발생했습니다."),
 	INVALID_S3_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청으로 인해 S3 Presigned URL 생성에 실패했습니다."),


### PR DESCRIPTION
프로젝트 상세 정보를 조회하는 단건 조회 API를 구현했습니다.

### 주요 변경 사항
- `GET /projects/{projectId}` 엔드포인트 추가
- `ProjectDetailResponse` DTO 생성 및 적용
- 프로젝트에 연결된 이미지 URL 목록 반환
- 클라이언트 이름 및 프로필 이미지 정보 포함
- 프로젝트가 존재하지 않을 경우 예외 처리 (`PROJECT_NOT_FOUND`)

### 테스트
- Postman을 통한 프로젝트 상세 조회 테스트 완료
- 이미지 없는 경우와 있는 경우 모두 확인

### 기타
- 추후 다건 조회, 상태 필터링 기능 개발 예정