### PR TITLE
feat: 결제 정산 기능 추가

### DIFF
--- a/src/main/java/com/ll/dopdang/domain/payment/controller/RebateAdminController.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/controller/RebateAdminController.java
@@ -1,0 +1,95 @@
+package com.ll.dopdang.domain.payment.controller;
+
+import java.time.YearMonth;
+import java.util.Map;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ll.dopdang.domain.payment.service.RebateService;
+import com.ll.dopdang.domain.payment.util.RebateVerifier;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 정산 관리자 API 컨트롤러
+ */
+@Slf4j
+@RestController
+@RequestMapping("/admin/rebate")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "정산 관리자 API", description = "정산 데이터 검증 및 관리 API")
+public class RebateAdminController {
+
+	private final RebateVerifier rebateVerifier;
+	private final RebateService rebateService;
+
+	@Operation(summary = "월별 정산 데이터 검증", description = "특정 월의 정산 데이터를 검증합니다.")
+	@GetMapping("/verify")
+	public ResponseEntity<Map<String, Object>> verifyRebate(
+		@Parameter(description = "정산 대상 년월 (yyyy-MM 형식, 미입력시 전월)", example = "2025-04")
+		@RequestParam(defaultValue = "#{T(java.time.YearMonth).now().minusMonths(1).toString()}")
+		@DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth) {
+
+		Map<String, Object> verificationResult = rebateVerifier.verifyMonthlyRebate(yearMonth);
+		return ResponseEntity.ok(verificationResult);
+	}
+
+	@Operation(summary = "전문가별 정산 데이터 검증", description = "특정 전문가의 정산 데이터를 검증합니다.")
+	@GetMapping("/verify/expert/{expertId}")
+	public ResponseEntity<Map<String, Object>> verifyExpertRebate(
+		@PathVariable Long expertId,
+		@Parameter(description = "정산 대상 년월 (yyyy-MM 형식, 미입력시 전월)", example = "2025-04")
+		@RequestParam(defaultValue = "#{T(java.time.YearMonth).now().minusMonths(1).toString()}")
+		@DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth) {
+
+		Map<String, Object> verificationResult = rebateVerifier.verifyExpertRebate(expertId, yearMonth);
+		return ResponseEntity.ok(verificationResult);
+	}
+
+	@Operation(summary = "수동 정산 데이터 생성", description = "특정 월의 정산 데이터를 수동으로 생성합니다.")
+	@GetMapping("/create")
+	public ResponseEntity<Map<String, Object>> createRebateData(
+		@Parameter(description = "정산 대상 년월 (yyyy-MM 형식, 미입력시 전월)", example = "2025-04")
+		@RequestParam(defaultValue = "#{T(java.time.YearMonth).now().minusMonths(1).toString()}")
+		@DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth) {
+
+		int count = rebateService.createRebateDataManually(yearMonth);
+
+		Map<String, Object> result = Map.of(
+			"yearMonth", yearMonth.toString(),
+			"count", count,
+			"message", count + "개의 정산 데이터가 생성되었습니다."
+		);
+
+		return ResponseEntity.ok(result);
+	}
+
+	@Operation(summary = "정산 처리 실행", description = "정산 처리를 수동으로 실행합니다. 년월을 지정하지 않으면 전월 정산을 처리합니다.")
+	@GetMapping("/process")
+	public ResponseEntity<Map<String, Object>> processRebate(
+		@Parameter(description = "정산 대상 년월 (yyyy-MM 형식, 미입력시 전월)", example = "2023-05")
+		@RequestParam(defaultValue = "#{T(java.time.YearMonth).now().minusMonths(1).toString()}")
+		@DateTimeFormat(pattern = "yyyy-MM") YearMonth yearMonth) {
+
+		// 서비스 메소드 호출
+		rebateService.processMonthlyRebate(yearMonth);
+
+		String message = String.format("%s에 대한 정산 처리가 완료되었습니다.", yearMonth);
+
+		Map<String, Object> result = Map.of("message", message);
+
+		return ResponseEntity.ok(result);
+	}
+}

--- a/src/main/java/com/ll/dopdang/domain/payment/entity/Payment.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/entity/Payment.java
@@ -71,6 +71,7 @@ public class Payment {
 	@Column(name = "total_price", precision = 10, scale = 2)
 	private BigDecimal totalPrice;
 
+	@Deprecated
 	@Column(name = "total_fee", precision = 10, scale = 2)
 	private BigDecimal totalFee;
 

--- a/src/main/java/com/ll/dopdang/domain/payment/entity/Rebate.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/entity/Rebate.java
@@ -1,0 +1,158 @@
+package com.ll.dopdang.domain.payment.entity;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+
+import com.ll.dopdang.domain.member.entity.Member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 정산 정보를 저장하는 엔티티
+ */
+@Entity
+@Table(name = "rebate")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Rebate {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "payment_id")
+	private Payment payment;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "expert_id")
+	private Member expert;
+
+	@Column(name = "rebate_year_month")
+	private String rebateYearMonth; // 정산 년월 (YYYY-MM 형식)
+
+	@Column(name = "original_amount", precision = 10, scale = 2)
+	private BigDecimal originalAmount; // 원래 결제 금액
+
+	@Column(name = "canceled_amount", precision = 10, scale = 2)
+	private BigDecimal canceledAmount; // 취소된 금액
+
+	@Column(name = "fee_amount", precision = 10, scale = 2)
+	private BigDecimal feeAmount; // 수수료 금액
+
+	@Column(name = "rebate_amount", precision = 10, scale = 2)
+	private BigDecimal rebateAmount; // 정산 금액 (수수료 제외)
+
+	@Column(name = "payment_date")
+	private LocalDateTime paymentDate; // 원 결제일
+
+	@Column(name = "rebate_date")
+	private LocalDateTime rebateDate; // 정산 처리일
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status")
+	private RebateStatus status; // 정산 상태
+
+	@Column(name = "payment_type")
+	@Enumerated(EnumType.STRING)
+	private PaymentType paymentType; // 결제 유형
+
+	@Column(name = "reference_id")
+	private Long referenceId; // 참조 ID (계약 ID 등)
+
+	@Column(name = "items_summary")
+	private String itemsSummary; // 결제 항목 요약
+
+	/**
+	 * Payment 엔티티로부터 Rebate 엔티티를 생성하는 정적 팩토리 메서드
+	 *
+	 * @param payment 결제 정보
+	 * @param rebateYearMonth 정산 년월
+	 * @return 생성된 Rebate 엔티티
+	 */
+	public static Rebate createFromPayment(Payment payment, BigDecimal feeRate, Member expert,
+		YearMonth rebateYearMonth) {
+		// 남은 결제 금액 (부분 취소 반영)
+		BigDecimal remainingAmount = payment.getRemainingAmount();
+
+		// 수수료 계산 (남은 금액의 10%)
+		BigDecimal feeAmount = remainingAmount.multiply(feeRate).setScale(2, RoundingMode.HALF_UP);
+
+		// 정산 금액 계산 (남은 금액 - 수수료)
+		BigDecimal rebateAmount = remainingAmount.subtract(feeAmount);
+
+		return Rebate.builder()
+			.payment(payment)
+			.expert(expert)
+			.rebateYearMonth(rebateYearMonth.toString())
+			.originalAmount(payment.getTotalPrice())
+			.canceledAmount(payment.getCanceledAmount())
+			.feeAmount(feeAmount)
+			.rebateAmount(rebateAmount)
+			.paymentDate(payment.getPaymentDate())
+			.rebateDate(null) // 정산 처리 시 설정
+			.status(RebateStatus.PENDING)
+			.paymentType(payment.getPaymentType())
+			.referenceId(payment.getReferenceId())
+			.itemsSummary(payment.getItemsSummary())
+			.build();
+	}
+
+	/**
+	 * 정산 처리를 완료하는 메서드
+	 */
+	public void complete() {
+		this.status = RebateStatus.COMPLETED;
+		this.rebateDate = LocalDateTime.now();
+	}
+
+	/**
+	 * 정산 처리를 실패로 표시하는 메서드
+	 */
+	public void fail() {
+		this.status = RebateStatus.FAILED;
+	}
+
+	/**
+	 * 정산 처리를 보류로 표시하는 메서드
+	 */
+	public void hold() {
+		this.status = RebateStatus.HELD;
+	}
+
+	/**
+	 * 정산 대상 여부를 확인하는 메서드
+	 *
+	 * @return 정산 대상 여부
+	 */
+	public boolean isEligibleForRebate() {
+		return !payment.isCanceled() && status == RebateStatus.PENDING;
+	}
+
+	/**
+	 * 총 금액을 반환하는 메서드 (정산 금액 + 수수료)
+	 *
+	 * @return 총 금액
+	 */
+	public BigDecimal getTotalAmount() {
+		return rebateAmount.add(feeAmount);
+	}
+}

--- a/src/main/java/com/ll/dopdang/domain/payment/entity/RebateStatus.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/entity/RebateStatus.java
@@ -1,0 +1,20 @@
+package com.ll.dopdang.domain.payment.entity;
+
+import lombok.Getter;
+
+/**
+ * 정산 상태를 나타내는 열거형
+ */
+@Getter
+public enum RebateStatus {
+	PENDING("정산 대기"),
+	COMPLETED("정산 완료"),
+	FAILED("정산 실패"),
+	HELD("정산 보류");
+
+	private final String description;
+
+	RebateStatus(String description) {
+		this.description = description;
+	}
+}

--- a/src/main/java/com/ll/dopdang/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/repository/PaymentRepository.java
@@ -1,10 +1,13 @@
 package com.ll.dopdang.domain.payment.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.ll.dopdang.domain.member.entity.Member;
 import com.ll.dopdang.domain.payment.entity.Payment;
 import com.ll.dopdang.domain.payment.entity.PaymentStatus;
 import com.ll.dopdang.domain.payment.entity.PaymentType;
@@ -12,9 +15,29 @@ import com.ll.dopdang.domain.payment.entity.PaymentType;
 @Repository
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
-	boolean existsByPaymentTypeAndReferenceId(PaymentType paymentType, Long referenceId);
-
+	/**
+	 * 결제 유형과 참조 ID로 결제 정보 조회
+	 */
 	Optional<Payment> findByPaymentTypeAndReferenceId(PaymentType paymentType, Long referenceId);
+
+	/**
+	 * 특정 회원의 결제 목록 조회
+	 */
+	List<Payment> findByMember(Member member);
+
+	/**
+	 * 특정 기간 내의 결제 목록 조회
+	 */
+	List<Payment> findByPaymentDateBetween(LocalDateTime start, LocalDateTime end);
+
+	/**
+	 * 특정 기간 및 상태의 결제 목록 조회
+	 */
+	List<Payment> findByPaymentDateBetweenAndStatus(
+		LocalDateTime start,
+		LocalDateTime end,
+		PaymentStatus status
+	);
 
 	/**
 	 * 결제 유형, 참조 ID, 결제 상태로 결제 정보를 조회합니다.

--- a/src/main/java/com/ll/dopdang/domain/payment/repository/RebateRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/repository/RebateRepository.java
@@ -1,0 +1,35 @@
+package com.ll.dopdang.domain.payment.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ll.dopdang.domain.payment.entity.Payment;
+import com.ll.dopdang.domain.payment.entity.Rebate;
+import com.ll.dopdang.domain.payment.entity.RebateStatus;
+
+@Repository
+public interface RebateRepository extends JpaRepository<Rebate, Long> {
+
+	/**
+	 * 특정 결제에 대한 정산 정보 조회
+	 */
+	Optional<Rebate> findByPayment(Payment payment);
+
+	/**
+	 * 특정 년월의 정산 목록 조회
+	 */
+	List<Rebate> findByRebateYearMonth(String rebateYearMonth);
+
+	/**
+	 * 특정 년월 및 상태의 정산 목록 조회
+	 */
+	List<Rebate> findByRebateYearMonthAndStatus(String rebateYearMonth, RebateStatus status);
+
+	/**
+	 * 특정 전문가 ID 및 년월의 정산 목록 조회
+	 */
+	List<Rebate> findByExpertIdAndRebateYearMonth(Long expertId, String rebateYearMonth);
+}

--- a/src/main/java/com/ll/dopdang/domain/payment/service/RebateService.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/service/RebateService.java
@@ -1,0 +1,218 @@
+package com.ll.dopdang.domain.payment.service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ll.dopdang.domain.member.entity.Member;
+import com.ll.dopdang.domain.payment.entity.Payment;
+import com.ll.dopdang.domain.payment.entity.PaymentStatus;
+import com.ll.dopdang.domain.payment.entity.Rebate;
+import com.ll.dopdang.domain.payment.entity.RebateStatus;
+import com.ll.dopdang.domain.payment.repository.PaymentRepository;
+import com.ll.dopdang.domain.payment.repository.RebateRepository;
+import com.ll.dopdang.domain.payment.strategy.info.PaymentInfoProviderFactory;
+import com.ll.dopdang.domain.payment.strategy.info.PaymentOrderInfoProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 정산 처리를 담당하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RebateService {
+
+	private final PaymentRepository paymentRepository;
+	private final RebateRepository rebateRepository;
+	private final PaymentInfoProviderFactory paymentInfoProviderFactory;
+
+	@Value("${payment.fee.rate}")
+	private BigDecimal feeRate;
+
+	/**
+	 * 매일 자정에 전일 결제 건에 대한 정산 데이터 생성
+	 */
+	@Scheduled(cron = "0 0 0 * * ?")
+	@Transactional
+	public void createDailyRebateData() {
+		// 전일 계산
+		YearMonth currentMonth = YearMonth.now();
+		LocalDateTime startDateTime = LocalDate.now().minusDays(1).atStartOfDay();
+		LocalDateTime endDateTime = LocalDate.now().atStartOfDay();
+
+		log.info("정산 데이터 생성 시작: {} - {}", startDateTime, endDateTime);
+
+		int createdCount = createRebateDataForPeriod(startDateTime, endDateTime, currentMonth);
+
+		log.info("정산 데이터 생성 완료: {} 건", createdCount);
+	}
+
+	/**
+	 * 특정 기간에 대한 정산 데이터 생성
+	 *
+	 * @param startDateTime 시작 날짜 및 시간
+	 * @param endDateTime 종료 날짜 및 시간
+	 * @param yearMonth 정산 대상 년월
+	 * @return 생성된 정산 데이터 수
+	 */
+	private int createRebateDataForPeriod(LocalDateTime startDateTime, LocalDateTime endDateTime, YearMonth yearMonth) {
+		// 해당 기간에 결제 완료된 건들 조회
+		List<Payment> eligiblePayments = getEligiblePayments(startDateTime, endDateTime);
+
+		// 이미 정산 데이터가 있는 결제는 제외
+		eligiblePayments = filterExistingRebates(eligiblePayments);
+
+		// 정산 데이터 생성
+		List<Rebate> rebates = createRebatesFromPayments(eligiblePayments, yearMonth);
+
+		// 저장
+		rebateRepository.saveAll(rebates);
+
+		return rebates.size();
+	}
+
+	/**
+	 * 매월 15일 오전 2시에 정산 처리 실행
+	 * 스케줄러가 실행하는 메서드.
+	 */
+	@Scheduled(cron = "0 0 2 15 * ?")
+	@Transactional
+	public void processMonthlyRebate() {
+		// 전월 계산
+		YearMonth previousMonth = YearMonth.now().minusMonths(1);
+
+		processMonthlyRebate(previousMonth);
+	}
+
+	/**
+	 * 수동으로 정산 처리 실행
+	 *
+	 * @param yearMonth 정산 대상 년월
+	 */
+	@Transactional
+	public void processMonthlyRebate(YearMonth yearMonth) {
+		String yearMonthStr = yearMonth.toString();
+
+		log.info("정산 처리 시작: {}", yearMonthStr);
+
+		// 정산 대기 상태인 건들 조회
+		List<Rebate> pendingRebates = rebateRepository.findByRebateYearMonthAndStatus(
+			yearMonthStr, RebateStatus.PENDING);
+
+		log.info("정산 처리 대상 건수: {}", pendingRebates.size());
+
+		// 정산 처리
+		processRebates(pendingRebates);
+
+		log.info("정산 처리 완료: {}", yearMonthStr);
+	}
+
+	/**
+	 * 정산 처리 실행
+	 *
+	 * @param rebates 처리할 정산 목록
+	 */
+	private void processRebates(List<Rebate> rebates) {
+		for (Rebate rebate : rebates) {
+			try {
+				// 여기에 실제 정산 처리 로직 구현 (외부 API 호출 등)
+				// 정산 완료 처리
+				rebate.complete();
+			} catch (Exception e) {
+				log.error("정산 처리 실패: {}", rebate.getId(), e);
+				rebate.fail();
+			}
+		}
+
+		rebateRepository.saveAll(rebates);
+	}
+
+	/**
+	 * 수동으로 정산 데이터 생성
+	 *
+	 * @param yearMonth 정산 대상 년월
+	 * @return 생성된 정산 데이터 수
+	 */
+	@Transactional
+	public int createRebateDataManually(YearMonth yearMonth) {
+		return createRebateData(yearMonth);
+	}
+
+	/**
+	 * 정산 데이터 생성 공통 로직
+	 *
+	 * @param yearMonth 정산 대상 년월
+	 * @return 생성된 정산 데이터 수
+	 */
+	private int createRebateData(YearMonth yearMonth) {
+		YearMonth nextMonth = yearMonth.plusMonths(1);
+
+		LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
+		LocalDateTime endDateTime = nextMonth.atDay(1).atStartOfDay();
+
+		// 해당 월에 결제 완료된 건들 조회
+		List<Payment> eligiblePayments = getEligiblePayments(startDateTime, endDateTime);
+
+		// 이미 정산 데이터가 있는 결제는 제외
+		eligiblePayments = filterExistingRebates(eligiblePayments);
+
+		// 정산 데이터 생성
+		List<Rebate> rebates = createRebatesFromPayments(eligiblePayments, yearMonth);
+
+		// 저장
+		rebateRepository.saveAll(rebates);
+
+		return rebates.size();
+	}
+
+	/**
+	 * 정산 대상 결제 목록 조회
+	 */
+	private List<Payment> getEligiblePayments(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		// 결제 완료된 건들 조회
+		List<Payment> eligiblePayments = paymentRepository.findByPaymentDateBetweenAndStatus(
+			startDateTime, endDateTime, PaymentStatus.PAID);
+
+		// 부분 취소된 건도 포함
+		eligiblePayments.addAll(paymentRepository.findByPaymentDateBetweenAndStatus(
+			startDateTime, endDateTime, PaymentStatus.PARTIALLY_CANCELED));
+
+		return eligiblePayments;
+	}
+
+	/**
+	 * 이미 정산 데이터가 있는 결제 필터링
+	 */
+	private List<Payment> filterExistingRebates(List<Payment> payments) {
+		return payments.stream()
+			.filter(payment -> rebateRepository.findByPayment(payment).isEmpty())
+			.collect(Collectors.toList());
+	}
+
+	/**
+	 * 결제 목록으로부터 정산 데이터 생성
+	 */
+	private List<Rebate> createRebatesFromPayments(List<Payment> payments, YearMonth yearMonth) {
+		return payments.stream()
+			.map(payment -> {
+				PaymentOrderInfoProvider infoProvider = paymentInfoProviderFactory
+					.getProvider(payment.getPaymentType());                  // 결제 유형에 맞는 정보 제공자 가져오기
+				Map<String, Object> additionalInfo = infoProvider
+					.provideAdditionalInfo(payment.getReferenceId());        // 추가 정보 조회 (전문가 정보 포함)
+				Member expert = (Member)additionalInfo.get("expert");        // 전문가 정보 추출
+				return Rebate.createFromPayment(payment, feeRate, expert, yearMonth); // Rebate 생성
+			}).collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/ll/dopdang/domain/payment/strategy/info/ProjectPaymentInfoProvider.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/strategy/info/ProjectPaymentInfoProvider.java
@@ -42,6 +42,7 @@ public class ProjectPaymentInfoProvider implements PaymentOrderInfoProvider {
 		additionalInfo.put("endDate", contract.getEndDate());
 		additionalInfo.put("project", project);
 		additionalInfo.put("contract", contract);
+		additionalInfo.put("expert", contract.getExpert());
 
 		return additionalInfo;
 	}

--- a/src/main/java/com/ll/dopdang/domain/payment/util/RebateVerifier.java
+++ b/src/main/java/com/ll/dopdang/domain/payment/util/RebateVerifier.java
@@ -1,0 +1,273 @@
+package com.ll.dopdang.domain.payment.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.ll.dopdang.domain.payment.entity.Payment;
+import com.ll.dopdang.domain.payment.entity.PaymentStatus;
+import com.ll.dopdang.domain.payment.entity.Rebate;
+import com.ll.dopdang.domain.payment.entity.RebateStatus;
+import com.ll.dopdang.domain.payment.repository.PaymentRepository;
+import com.ll.dopdang.domain.payment.repository.RebateRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 정산 결과를 검증하는 유틸리티 클래스
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RebateVerifier {
+
+	private final RebateRepository rebateRepository;
+	private final PaymentRepository paymentRepository;
+
+	@Value("${payment.fee.rate}")
+	private BigDecimal feeRate;
+
+	/**
+	 * 특정 월의 정산 데이터 검증
+	 *
+	 * @param yearMonth 검증할 년월
+	 * @return 검증 결과
+	 */
+	public Map<String, Object> verifyMonthlyRebate(YearMonth yearMonth) {
+		String yearMonthStr = yearMonth.toString();
+		log.info("정산 데이터 검증 시작: {}", yearMonthStr);
+
+		// 해당 월의 정산 데이터 조회
+		List<Rebate> rebates = rebateRepository.findByRebateYearMonth(yearMonthStr);
+
+		// 해당 월의 결제 데이터 조회
+		LocalDateTime startDateTime = yearMonth.atDay(1).atStartOfDay();
+		LocalDateTime endDateTime = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
+		List<Payment> payments = paymentRepository.findByPaymentDateBetween(startDateTime, endDateTime);
+
+		// 결제 건수와 정산 건수 비교
+		long eligiblePaymentCount = countEligiblePayments(payments);
+
+		// 기본 결과 맵 생성
+		Map<String, Object> result = createBaseResultMap(yearMonthStr, rebates);
+		result.put("totalPayments", payments.size());
+		result.put("eligiblePayments", eligiblePaymentCount);
+
+		// 불일치 항목 확인
+		List<String> discrepancies = new ArrayList<>();
+
+		// 결제 건수와 정산 건수 비교
+		if (eligiblePaymentCount != rebates.size()) {
+			discrepancies.add(String.format(
+				"결제 건수와 정산 건수가 일치하지 않습니다. (적격 결제: %d건, 정산: %d건)",
+				eligiblePaymentCount, rebates.size()));
+		}
+
+		// 각 정산 데이터의 금액 검증
+		List<Map<String, Object>> incorrectRebates = verifyRebateAmounts(rebates);
+		addDiscrepancyIfNeeded(discrepancies, incorrectRebates, "일부 정산 데이터의 금액이 올바르지 않습니다. (%d건)");
+		if (!incorrectRebates.isEmpty()) {
+			result.put("incorrectRebates", incorrectRebates);
+		}
+
+		// 정산되지 않은 결제 확인
+		List<Map<String, Object>> unprocessedPayments = findUnprocessedPayments(payments, rebates);
+		addDiscrepancyIfNeeded(discrepancies, unprocessedPayments, "일부 적격 결제가 정산되지 않았습니다. (%d건)");
+		if (!unprocessedPayments.isEmpty()) {
+			result.put("unprocessedPayments", unprocessedPayments);
+		}
+
+		// 최종 결과 설정
+		finalizeResult(result, discrepancies);
+
+		log.info("정산 데이터 검증 완료: {} (유효: {})", yearMonthStr, discrepancies.isEmpty());
+		return result;
+	}
+
+	/**
+	 * 특정 전문가의 정산 데이터 검증
+	 *
+	 * @param expertId 전문가 ID
+	 * @param yearMonth 검증할 년월
+	 * @return 검증 결과
+	 */
+	public Map<String, Object> verifyExpertRebate(Long expertId, YearMonth yearMonth) {
+		String yearMonthStr = yearMonth.toString();
+		log.info("전문가 정산 데이터 검증 시작: expertId={}, yearMonth={}", expertId, yearMonthStr);
+
+		// 해당 전문가의 정산 데이터 조회
+		List<Rebate> rebates = rebateRepository.findByExpertIdAndRebateYearMonth(expertId, yearMonthStr);
+
+		// 기본 결과 맵 생성
+		Map<String, Object> result = createBaseResultMap(yearMonthStr, rebates);
+		result.put("expertId", expertId);
+
+		// 데이터가 없는 경우 처리
+		if (rebates.isEmpty()) {
+			List<String> discrepancies = List.of("해당 전문가의 정산 데이터가 없습니다.");
+			finalizeResult(result, discrepancies);
+			return result;
+		}
+
+		// 각 정산 데이터의 금액 검증
+		List<Map<String, Object>> incorrectRebates = verifyRebateAmounts(rebates);
+
+		// 불일치 항목 확인
+		List<String> discrepancies = new ArrayList<>();
+		addDiscrepancyIfNeeded(discrepancies, incorrectRebates, "일부 정산 데이터의 금액이 올바르지 않습니다. (%d건)");
+
+		if (!incorrectRebates.isEmpty()) {
+			result.put("incorrectRebates", incorrectRebates);
+		}
+
+		// 최종 결과 설정
+		finalizeResult(result, discrepancies);
+
+		log.info("전문가 정산 데이터 검증 완료: expertId={}, yearMonth={} (유효: {})",
+			expertId, yearMonthStr, discrepancies.isEmpty());
+		return result;
+	}
+
+	/**
+	 * 적격 결제 건수를 계산
+	 */
+	private long countEligiblePayments(List<Payment> payments) {
+		return payments.stream()
+			.filter(p -> p.getStatus() == PaymentStatus.PAID || p.getStatus() == PaymentStatus.PARTIALLY_CANCELED)
+			.count();
+	}
+
+	/**
+	 * 기본 결과 맵 생성
+	 */
+	private Map<String, Object> createBaseResultMap(String yearMonthStr, List<Rebate> rebates) {
+		// 정산 금액 합계 계산
+		BigDecimal totalRebateAmount = rebates.stream()
+			.map(Rebate::getRebateAmount)
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+
+		BigDecimal totalFeeAmount = rebates.stream()
+			.map(Rebate::getFeeAmount)
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+
+		// 상태별 건수
+		Map<RebateStatus, Long> statusCounts = rebates.stream()
+			.collect(Collectors.groupingBy(Rebate::getStatus, Collectors.counting()));
+
+		// 결과 맵 생성
+		Map<String, Object> result = new HashMap<>();
+		result.put("yearMonth", yearMonthStr);
+		result.put("totalRebates", rebates.size());
+		result.put("totalRebateAmount", totalRebateAmount);
+		result.put("totalFeeAmount", totalFeeAmount);
+		result.put("statusCounts", statusCounts);
+
+		return result;
+	}
+
+	/**
+	 * 정산 금액 검증
+	 */
+	private List<Map<String, Object>> verifyRebateAmounts(List<Rebate> rebates) {
+		List<Map<String, Object>> incorrectRebates = new ArrayList<>();
+
+		for (Rebate rebate : rebates) {
+			Payment payment = rebate.getPayment();
+			BigDecimal remainingAmount = payment.getRemainingAmount();
+			BigDecimal expectedFeeAmount = calculateExpectedFeeAmount(remainingAmount);
+			BigDecimal expectedRebateAmount = remainingAmount.subtract(expectedFeeAmount);
+
+			if (!rebate.getFeeAmount().equals(expectedFeeAmount)
+				|| !rebate.getRebateAmount().equals(expectedRebateAmount)) {
+
+				Map<String, Object> incorrectRebate = new HashMap<>();
+				incorrectRebate.put("rebateId", rebate.getId());
+				incorrectRebate.put("paymentId", payment.getId());
+				incorrectRebate.put("actualFeeAmount", rebate.getFeeAmount());
+				incorrectRebate.put("expectedFeeAmount", expectedFeeAmount);
+				incorrectRebate.put("actualRebateAmount", rebate.getRebateAmount());
+				incorrectRebate.put("expectedRebateAmount", expectedRebateAmount);
+				incorrectRebate.put("remainingAmount", remainingAmount);
+
+				// 전문가 정보 추가 (있는 경우)
+				if (rebate.getExpert() != null) {
+					incorrectRebate.put("expertId", rebate.getExpert().getId());
+					incorrectRebate.put("expertName", rebate.getExpert().getName());
+				}
+
+				incorrectRebates.add(incorrectRebate);
+			}
+		}
+
+		return incorrectRebates;
+	}
+
+	/**
+	 * 예상 수수료 금액 계산
+	 */
+	private BigDecimal calculateExpectedFeeAmount(BigDecimal amount) {
+		return amount.multiply(feeRate).setScale(2, RoundingMode.HALF_UP);
+	}
+
+	/**
+	 * 정산되지 않은 결제 찾기
+	 */
+	private List<Map<String, Object>> findUnprocessedPayments(List<Payment> payments, List<Rebate> rebates) {
+		List<Map<String, Object>> unprocessedPayments = new ArrayList<>();
+
+		for (Payment payment : payments) {
+			if (isEligibleForRebate(payment)
+				&& rebates.stream().noneMatch(r -> r.getPayment().getId().equals(payment.getId()))) {
+
+				Map<String, Object> unprocessedPayment = new HashMap<>();
+				unprocessedPayment.put("paymentId", payment.getId());
+				unprocessedPayment.put("paymentKey", payment.getPaymentKey());
+				unprocessedPayment.put("originalAmount", payment.getTotalPrice());
+				unprocessedPayment.put("remainingAmount", payment.getRemainingAmount());
+				unprocessedPayment.put("paymentDate", payment.getPaymentDate());
+				unprocessedPayment.put("status", payment.getStatus());
+				unprocessedPayment.put("paymentType", payment.getPaymentType());
+				unprocessedPayment.put("referenceId", payment.getReferenceId());
+
+				unprocessedPayments.add(unprocessedPayment);
+			}
+		}
+
+		return unprocessedPayments;
+	}
+
+	/**
+	 * 결제가 정산 대상인지 확인
+	 */
+	private boolean isEligibleForRebate(Payment payment) {
+		return payment.getStatus() == PaymentStatus.PAID
+			|| payment.getStatus() == PaymentStatus.PARTIALLY_CANCELED;
+	}
+
+	/**
+	 * 불일치 항목이 있으면 추가
+	 */
+	private void addDiscrepancyIfNeeded(List<String> discrepancies, List<?> items, String format) {
+		if (!items.isEmpty()) {
+			discrepancies.add(String.format(format, items.size()));
+		}
+	}
+
+	/**
+	 * 최종 결과 설정
+	 */
+	private void finalizeResult(Map<String, Object> result, List<String> discrepancies) {
+		result.put("discrepancies", discrepancies);
+		result.put("isValid", discrepancies.isEmpty());
+	}
+}


### PR DESCRIPTION
## 결제 정산 기능 추가

- 결제 후 전문가에게 정산하는 기능을 구현했습니다.
- payment 테이블의 수수료 관련 필드는 제거될 예정입니다.
- 
### 구현 기능
- [x] 매일 자정에 전일 결제건에 대한 정산 예정 데이터 생성
- [x] 매월 15일 새벽 2시에 정산 예정 데이터 일괄 정산 완료 처리
- [x] 수동으로 정산 예정 데이터 생성 및 정산 처리를 할 수 있는 컨트롤러 메서드 작성
- [x] 월별 전체/전문가별 정산 데이터를 검증할 수 있는 컨트롤러 메서드 작성

관련 이슈: #22 