### PR TITLE
feat: 상품 조회 시 재고가 있는 상품이 먼저 표시되도록 정렬 로직 변경

### DIFF
--- a/src/main/java/com/ll/dopdang/domain/store/controller/ProductController.java
+++ b/src/main/java/com/ll/dopdang/domain/store/controller/ProductController.java
@@ -62,7 +62,7 @@ public class ProductController {
 	@GetMapping
 	public ResponseEntity<?> getAllProducts(
 		@RequestParam(required = false) Long categoryId, // 선택한 제품 타입
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+		@PageableDefault(size = 10, sort = "created_at", direction = Sort.Direction.DESC) Pageable pageable) {
 
 		ProductListPageResponse response = productService.getAllProducts(pageable, categoryId);
 		return ResponseEntity.ok(response);

--- a/src/main/java/com/ll/dopdang/domain/store/dto/ProductListResponse.java
+++ b/src/main/java/com/ll/dopdang/domain/store/dto/ProductListResponse.java
@@ -20,6 +20,7 @@ public class ProductListResponse {
 	private String name;
 	private String description;
 	private BigDecimal price;
+	private Integer stock;
 	private ProductType productType;
 	private String thumbnailUrl;
 	private String expertName;
@@ -32,6 +33,7 @@ public class ProductListResponse {
 			.name(product.getTitle())
 			.description(product.getDescription())
 			.price(product.getPrice())
+			.stock(product.getStock())
 			.productType(product.getProductType())
 			.thumbnailUrl(product.getThumbnailImage())
 			.expertName(product.getExpert().getMember().getName())

--- a/src/main/java/com/ll/dopdang/domain/store/repository/ProductRepository.java
+++ b/src/main/java/com/ll/dopdang/domain/store/repository/ProductRepository.java
@@ -14,6 +14,13 @@ import com.ll.dopdang.domain.store.entity.Product;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 	Optional<Product> findById(Long id);
 
-	@Query("SELECT p FROM Product p WHERE p.category.id = :categoryId")
-	Page<Product> findAllByCategoryId(Long categoryId, Pageable pageable);
+	@Query(value = "SELECT * FROM product WHERE category_id = :categoryId " +
+		"ORDER BY CASE WHEN stock > 0 THEN 0 ELSE 1 END",
+		nativeQuery = true)
+	Page<Product> findAllByCategoryOrderByStockAndCreatedAtDesc(Long categoryId, Pageable pageable);
+
+	@Query(value = "SELECT * FROM product " +
+		"ORDER BY CASE WHEN stock > 0 THEN 0 ELSE 1 END",
+		nativeQuery = true)
+	Page<Product> findAll(Pageable pageable);
 }

--- a/src/main/java/com/ll/dopdang/domain/store/service/ProductService.java
+++ b/src/main/java/com/ll/dopdang/domain/store/service/ProductService.java
@@ -8,11 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ll.dopdang.domain.expert.category.entity.Category;
-import com.ll.dopdang.domain.expert.category.repository.CategoryRepository;
 import com.ll.dopdang.domain.expert.category.service.CategoryService;
 import com.ll.dopdang.domain.expert.entity.Expert;
 import com.ll.dopdang.domain.member.entity.Member;
-import com.ll.dopdang.domain.member.service.MemberService;
 import com.ll.dopdang.domain.member.service.MemberUtilService;
 import com.ll.dopdang.domain.store.dto.DigitalContentDetailResponse;
 import com.ll.dopdang.domain.store.dto.ProductCreateRequest;
@@ -38,9 +36,7 @@ public class ProductService {
 	public final MemberUtilService memberUtilService;
 	private final ProductRepository productRepository;
 	private final CategoryService categoryService;
-	private final CategoryRepository categoryRepository;
 	private final DigitalContentRepository digitalContentRepository;
-	private final MemberService memberService;
 
 	/**
 	 * 상품 생성 메서드
@@ -66,8 +62,9 @@ public class ProductService {
 	public ProductListPageResponse getAllProducts(Pageable pageable, Long categoryId) {
 		Page<Product> page;
 		if (categoryId != null) {
-			page = productRepository.findAllByCategoryId(categoryId, pageable);
+			page = productRepository.findAllByCategoryOrderByStockAndCreatedAtDesc(categoryId, pageable);
 		} else {
+			// findAllOrderByStockAvailabilityAndCreatedAtDesc
 			page = productRepository.findAll(pageable);
 		}
 


### PR DESCRIPTION
- 네이티브 SQL 쿼리를 사용하여 재고 기반 정렬 구현
- Pageable 정렬 파라미터 "createdAt"을 "created_at"으로 수정
  - JPQL에서 네이티브 SQL로 변경함에 따라 정렬 파라미터 이름 변경

- 상품 목록 응답(ProductListResponse)에 재고(stock) 정보 추가